### PR TITLE
Imports UIKit.h

### DIFF
--- a/UIColor+TBL.h
+++ b/UIColor+TBL.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface UIColor (TBL)
 


### PR DESCRIPTION
UIColor category doesn’t recognize UIColor because UIKit.h is not imported.